### PR TITLE
Upgrade to express

### DIFF
--- a/lib/glog.js
+++ b/lib/glog.js
@@ -87,7 +87,7 @@ Glog.prototype.load_articles = function(options, cb) {
 
 		// Remove incorrect extensions
 		for(var i=0; i<files.length; i++) {
-			if(path.extname(files[i]) !== '.txt' || path.extname(files[i]) !== '.md') {
+			if(path.extname(files[i]) !== '.txt' && path.extname(files[i]) !== '.md') {
 				console.log('Skipping file ' + files[i] + '  Incorrect extension');
 				files.splice(i,1);
 			}

--- a/lib/glog.js
+++ b/lib/glog.js
@@ -87,7 +87,7 @@ Glog.prototype.load_articles = function(options, cb) {
 
 		// Remove incorrect extensions
 		for(var i=0; i<files.length; i++) {
-			if(path.extname(files[i]) !== '.txt') {
+			if(path.extname(files[i]) !== '.txt' || path.extname(files[i]) !== '.md') {
 				console.log('Skipping file ' + files[i] + '  Incorrect extension');
 				files.splice(i,1);
 			}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"author" : "Guy Halford-Thompson",
 	"repository" : "git://github.com/guyht/Glog",
 	"dependencies" : {
-		"connect" : ">= 1.8.4",
+    "express":">=2.5.9",
 		"marked" : ">= 0.1.4",
 		"jade" : ">= 0.19.0",
 		"mocha": ">= 0.8.2",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 var glog = require('./lib/glog'),
-	connect = require('connect'),
+	express = require('express'),
 	path = require('path');
 
 
@@ -8,10 +8,10 @@ glog.rebuild(function() {
 
 		console.log('Starting server on port ' + options.port);
 
-		var server = connect.createServer(
-			connect.static(path.join('blog_repo', '/public')),
-			connect.staticCache(),
-			connect.router(function(app) {
+		var server = express.createServer(
+			express.static(path.join('blog_repo', '/public')),
+			express.staticCache(),
+			express.router(function(app) {
 				app.get('/__render', function(req, res, next) {
 					glog.rebuild(function() {
 						res.end();


### PR DESCRIPTION
I was having issue installing Glog, and realized that connect was at 2.3.0, instead of 1.8.4 per package.json. I installed connect@1.8.4 and it worked correctly. However I see that express maps 1 to 1 (at least with the functions you have used) with connect and Glog seems to work as expected with express@2.5.9.

Another solution would be locking connect@1.8.4, but switching to express will scale better.  
